### PR TITLE
GitHub repos

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,8 @@
 class UsersController < ApplicationController
   def show
     if current_user.token
-      github_decorator = GithubDecorator.new
-      @users_repos = github_decorator.list_five_repos(current_user)
+      github_decorator = GithubDecorator.new(current_user)
+      @users_repos = github_decorator.list_five_repos
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,10 @@
 class UsersController < ApplicationController
-  def show; end
+  def show
+    if current_user.token
+      github_decorator = GithubDecorator.new
+      @users_repos = github_decorator.list_five_repos(current_user)
+    end
+  end
 
   def new
     @user = User.new

--- a/app/decorator/github_decorator.rb
+++ b/app/decorator/github_decorator.rb
@@ -10,6 +10,12 @@ class GithubDecorator
   end
 
   def list_five_repos
-    @github_service.user_repos
+    repos = @github_service.user_repos
+    repos = repos[0..4].map do |repo|
+      UserRepository.new({
+        name: repo[:name],
+        html_url: repo[:html_url]
+        })
+    end
   end
 end

--- a/app/decorator/github_decorator.rb
+++ b/app/decorator/github_decorator.rb
@@ -11,7 +11,7 @@ class GithubDecorator
 
   def list_five_repos
     repos = @github_service.user_repos
-    repos = repos[0..4].map do |repo|
+    repos[0..4].map do |repo|
       UserRepository.new({
         name: repo[:name],
         html_url: repo[:html_url]

--- a/app/decorator/github_decorator.rb
+++ b/app/decorator/github_decorator.rb
@@ -1,0 +1,14 @@
+class GithubDecorator
+
+  def initialize
+    create_github_service
+  end
+
+  def create_github_service
+    @github_service = GithubService.new
+  end
+
+  def list_five_repos
+    @github_service.user_repos(current_user)
+  end
+end

--- a/app/decorator/github_decorator.rb
+++ b/app/decorator/github_decorator.rb
@@ -1,14 +1,15 @@
 class GithubDecorator
 
-  def initialize
+  def initialize(user)
+    @user = user
     create_github_service
   end
 
   def create_github_service
-    @github_service = GithubService.new
+    @github_service = GithubService.new(@user)
   end
 
   def list_five_repos
-    @github_service.user_repos(current_user)
+    @github_service.user_repos
   end
 end

--- a/app/poros/user_repository.rb
+++ b/app/poros/user_repository.rb
@@ -1,0 +1,8 @@
+class UserRepository
+
+  attr_reader :name, :url
+  def initialize(repo_data)
+    @name = repo_data[:name]
+    @url = repo_data[:html_url]
+  end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -14,7 +14,7 @@ class GithubService
 
   def conn
     Faraday.new(url: 'https://api.github.com') do |f|
-      f.headers['Authorization'] = "token 6d37f331aab131ad424243bdf9065ecc18e809be"
+      f.headers['Authorization'] = "token #{@user.token}"
     end
   end
 

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,0 +1,25 @@
+class GithubService
+
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def user_repos
+    get_json('user/repos')
+  end
+
+  private
+
+  def conn
+    Faraday.new(url: 'https://api.github.com') do |f|
+      f.headers['Authorization'] = "token 6d37f331aab131ad424243bdf9065ecc18e809be"
+    end
+  end
+
+  def get_json(url)
+    response = conn.get(url)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/app/services/youtube_service.rb
+++ b/app/services/youtube_service.rb
@@ -12,7 +12,7 @@ class YoutubeService
   end
 
   def conn
-    fara = Faraday.new(url: 'https://www.googleapis.com') do |f|
+    Faraday.new(url: 'https://www.googleapis.com') do |f|
       f.adapter Faraday.default_adapter
       f.params[:key] = ENV['YOUTUBE_API_KEY']
     end

--- a/app/services/youtube_service.rb
+++ b/app/services/youtube_service.rb
@@ -1,7 +1,6 @@
 class YoutubeService
   def video_info(id)
     params = { part: 'snippet,contentDetails,statistics', id: id }
-
     get_json('youtube/v3/videos', params)
   end
 
@@ -13,7 +12,7 @@ class YoutubeService
   end
 
   def conn
-    Faraday.new(url: 'https://www.googleapis.com') do |f|
+    fara = Faraday.new(url: 'https://www.googleapis.com') do |f|
       f.adapter Faraday.default_adapter
       f.params[:key] = ENV['YOUTUBE_API_KEY']
     end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,6 +12,14 @@
   </section>
 </section>
 
-<section id='github-repos'>
-
-</section>
+<% if current_user.token %>
+  <h2>My Repositories</h2>
+  <section id='github-repos'>
+    <ul>
+      <% @users_repos.each do |repo| %>
+        <li>Name: <%= repo.name %></li>
+        <li> <%= link_to "Github Link", repo.url %></li>
+      <% end %>
+    </ul>
+  </section>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,3 +11,7 @@
     <h1>Bookmarked Segments</h1>
   </section>
 </section>
+
+<section id='github-repos'>
+
+</section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -17,8 +17,7 @@
   <section id='github-repos'>
     <% @users_repos.each do |repo| %>
       <ul class="user-repo">
-        <li class="repo-name">Name: <%= repo.name %></li>
-        <li> <%= link_to "Github Link", repo.url %></li>
+        <li class="repo-name">Name: <%= link_to repo.name, repo.url %></li>
       </ul>
     <% end %>
   </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,11 +15,11 @@
 <% if current_user.token %>
   <h2>My Repositories</h2>
   <section id='github-repos'>
-    <ul>
-      <% @users_repos.each do |repo| %>
-        <li>Name: <%= repo.name %></li>
+    <% @users_repos.each do |repo| %>
+      <ul class="user-repo">
+        <li class="repo-name">Name: <%= repo.name %></li>
         <li> <%= link_to "Github Link", repo.url %></li>
-      <% end %>
-    </ul>
+      </ul>
+    <% end %>
   </section>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,7 +13,7 @@
 </section>
 
 <% if current_user.token %>
-  <h2>My Repositories</h2>
+  <h2>Github</h2>
   <section id='github-repos'>
     <% @users_repos.each do |repo| %>
       <ul class="user-repo">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,5 +1,3 @@
-Test Travis CI Works
-
 <div class="home-page-title">
   <h1>Video Tutorials</h1>
   <hr>

--- a/db/migrate/20200630211353_add_token_to_users.rb
+++ b/db/migrate/20200630211353_add_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddTokenToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_31_230036) do
+ActiveRecord::Schema.define(version: 2020_06_30_211353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 2018_07_31_230036) do
     t.integer "role", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "token"
     t.index ["email"], name: "index_users_on_email"
   end
 

--- a/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
+++ b/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
@@ -13,13 +13,36 @@ describe 'As a registered user' do
         expect(page).to have_css(".user-repo", count: 5)
       end
     end
-
+    # Not sure how to test this
     it 'Project names link to the repo on github' do
 
     end
 
     it 'Does not display a github section if the user does not have a token' do
+      user = create(:user)
 
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit '/dashboard'
+
+      expect(page).to_not have_css(".user-repo")
+    end
+
+    it 'Shows correct repos when there is more than one user with different github tokens' do
+      user = create(:user, token:  ENV["GITHUB_API_TOKEN"])
+      rostam = create(:user, token:  ENV["GITHUB_API_TOKEN_R"])
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit '/dashboard'
+
+      within('#github-repos') do
+        expect(page).to have_content("adopt_dont_shop_paired")
+        expect(page).to have_content("futbol")
+        expect(page).to have_content("monster_shop_2003")
+        expect(page).to have_content("activerecord-obstacle-course")
+        expect(page).to have_content("adopt_dont_shop_2003")
+      end
     end
   end
 end

--- a/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
+++ b/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
@@ -9,9 +9,8 @@ describe 'As a registered user' do
 
       visit '/dashboard'
 
-
       within('#github-repos') do
-        expect(find('ul.text')).to have_selector('li', count: 5)
+        expect(page).to have_css(".user-repo", count: 5)
       end
     end
 

--- a/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
+++ b/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe 'As a registered user' do
+  describe 'When I visit the dashboard' do
+    it 'I see a list of five of my github repos' do
+      user = create(:user, token:  "6d37f331aab131ad424243bdf9065ecc18e809be")
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit '/dashboard'
+
+
+      within('#github-repos') do
+        expect(find('ul.text')).to have_selector('li', count: 5)
+      end
+    end
+
+    it 'Project names link to the repo on github' do
+
+    end
+
+    it 'Does not display a github section if the user does not have a token' do
+
+    end
+  end
+end

--- a/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
+++ b/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
@@ -13,7 +13,7 @@ describe 'As a registered user' do
         expect(page).to have_css(".user-repo", count: 5)
       end
     end
-    # Not sure how to test this
+
     it 'Project names link to the repo on github' do
       user = create(:user, token:  ENV["GITHUB_API_TOKEN"])
 

--- a/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
+++ b/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
@@ -15,7 +15,17 @@ describe 'As a registered user' do
     end
     # Not sure how to test this
     it 'Project names link to the repo on github' do
+      user = create(:user, token:  ENV["GITHUB_API_TOKEN"])
 
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit '/dashboard'
+
+      expect(page).to have_link("adopt_dont_shop_paired", :href => "https://github.com/Ashkanthegreat/adopt_dont_shop_paired")
+      expect(page).to have_link("futbol", :href => "https://github.com/Lithnotep/futbol")
+      expect(page).to have_link("monster_shop_2003", :href => "https://github.com/madhalle/monster_shop_2003")
+      expect(page).to have_link("activerecord-obstacle-course", :href => "https://github.com/takeller/activerecord-obstacle-course")
+      expect(page).to have_link("adopt_dont_shop_2003", :href => "https://github.com/takeller/adopt_dont_shop_2003")
     end
 
     it 'Does not display a github section if the user does not have a token' do

--- a/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
+++ b/spec/features/user/user_can_see_github_repos_on_dashboard_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'As a registered user' do
   describe 'When I visit the dashboard' do
     it 'I see a list of five of my github repos' do
-      user = create(:user, token:  "6d37f331aab131ad424243bdf9065ecc18e809be")
+      user = create(:user, token:  ENV["GITHUB_API_TOKEN"])
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 


### PR DESCRIPTION
Paired Together
- Adds Github section to user show page
- Create Github Service to ping Github's API
- Uses Github Decorator to manipulate API response
- Adds UserRepo PORO to hold repository information
- Tests Edge case when user isn't logged in 
- Needs edge case testing for when user has less than 5 repos
- All tests passing 